### PR TITLE
PHP before 5.5 didnt support references to temporary values returned …

### DIFF
--- a/includes/class-breadcrumbs-builder.php
+++ b/includes/class-breadcrumbs-builder.php
@@ -131,8 +131,9 @@ class Breadcrumbs_Builder {
 
 			$blog = array();
 
-			if ( get_option( 'show_on_front' ) == 'page' && !empty( get_option( 'page_for_posts' ) ) ) {
-				$post = get_post(get_option('page_for_posts' ));
+			$page_for_posts = get_option( 'page_for_posts' );
+			if ( get_option( 'show_on_front' ) == 'page' && ! empty( $page_for_posts ) ) {
+				$post = get_post( $page_for_posts );
 				$blog['name'] = $post->the_title;
 				$blog['url'] = get_permalink($post->ID);
 				$blog['type'] = 'posts_page';


### PR DESCRIPTION
`empty()` needs to access value by reference (in order to check whether that reference points to something that exists), and PHP before 5.5 didn't support references to temporary values returned from functions.