### PR TITLE
Support child taxonomy in single page

### DIFF
--- a/includes/class-breadcrumbs-builder.php
+++ b/includes/class-breadcrumbs-builder.php
@@ -165,11 +165,18 @@ class Breadcrumbs_Builder {
 
 				if ( ! empty( $terms ) ) {
 					$term = array_shift( $terms );
-					unset( $terms );
+					$term_child = get_term_children( $term->term_id, $term->taxonomy );
 
-					$return = array_merge( $return,
-						array_reverse( $this->get_term_hierarchy( $term->term_id, $term->taxonomy ) )
-					);
+					if( count($term_child) > 0 ){
+						$term_childs = get_term( $term_child[0], $term->taxonomy );
+						$return = array_merge( $return,
+							array_reverse( $this->get_term_hierarchy( $term_childs->term_id, $term->taxonomy ) )
+						);
+					}else{
+						$return = array_merge( $return,
+							array_reverse( $this->get_term_hierarchy( $term->term_id, $term->taxonomy ) )
+						);
+					}
 				}
 			}
 


### PR DESCRIPTION
Hi! 
It's pull request for supporting the child taxonomy in single page. 
In blog post, if we have category like: 
Category Parrent -> Category Child -> Post name
The Category Child will be missing. I checked if the parent taxonomy has children then display it in the Breadcrumb. 
Any comments are welcome.
Thanks!